### PR TITLE
feat: scaffold VC memo bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Discord bot token
+DISCORD_TOKEN=
+
+# FriendliAI API key (or fallback OpenAI key)
+FRIENDLI_API_KEY=
+OPENAI_API_KEY=
+
+# Weaviate settings
+WEAVIATE_URL=
+WEAVIATE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # Investor-Decisions-Agent
-A Discord‑native VC Decision Memo Agent that converts a startup one‑pager into a short, transparent investment memo (verdict, rubric scores, pros/cons, risks, key metrics) with numbered citations to the underlying document chunks via Weaviate RAG, generated using FriendliAI as the inference engine.
+
+A Discord-native VC Decision Memo Agent that converts a startup one-pager into a short investment memo with citations.
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Configure environment**
+   Copy `.env.example` to `.env` and fill in your `DISCORD_TOKEN`, `FRIENDLI_API_KEY` (or `OPENAI_API_KEY`), and Weaviate credentials.
+3. **Ingest sample data**
+   ```bash
+   python ingest.py data/friendliai.txt --name friendliai
+   ```
+4. **Run the bot**
+   ```bash
+   python bot.py
+   ```
+
+## Discord Commands
+
+- `/ingest_company name:"<Company>" link:"<URL>" text:"<one-pager>"`
+- `/vc_decide name:"<Company>" stage:"<Seed|Pre-Seed|A|B>" check_size:"250k" horizon:"5y"`
+
+## Project Structure
+
+- `bot.py` – Discord bot with slash commands.
+- `ingest.py` – Offline ingestion script.
+- `prompts.py` – Prompt templates.
+- `weaviate_client.py` – Weaviate helpers for chunking, embedding, and retrieval.
+- `data/` – Example one-pagers.
+
+## Notes
+
+This is boilerplate code intended for demonstration and requires valid API keys and a running Weaviate instance.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,106 @@
+"""Discord bot providing VC decision memos."""
+from __future__ import annotations
+
+import json
+import os
+
+import discord
+from discord import app_commands
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from prompts import SYSTEM_PROMPT, format_user_prompt
+from weaviate_client import (
+    build_context,
+    chunk_text,
+    embed_chunks,
+    get_client,
+    query_company,
+    upsert_chunks,
+)
+
+load_dotenv()
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+tree = app_commands.CommandTree(client)
+
+
+@client.event
+async def on_ready():
+    await tree.sync()
+    print(f"Logged in as {client.user}")
+
+
+@tree.command(name="ingest_company", description="Ingest a company one-pager")
+async def ingest_company(interaction: discord.Interaction, name: str, link: str, text: str):
+    await interaction.response.defer(thinking=True, ephemeral=True)
+    wclient = get_client()
+    chunks = chunk_text(text)
+    vectors = embed_chunks(chunks)
+    upsert_chunks(wclient, name, name, link, chunks, vectors)
+    await interaction.followup.send(f"Ingested {len(chunks)} chunks for {name}", ephemeral=True)
+
+
+@tree.command(name="vc_decide", description="Generate a VC decision memo")
+async def vc_decide(
+    interaction: discord.Interaction,
+    name: str,
+    stage: str,
+    check_size: str,
+    horizon: str,
+):
+    await interaction.response.defer(thinking=True)
+    wclient = get_client()
+    docs = query_company(wclient, name, k=5)
+    if not docs:
+        await interaction.followup.send("Not enough evidence.")
+        return
+    avg_top3 = sum(d[1] for d in docs[:3]) / min(3, len(docs))
+    if avg_top3 > 0.8:
+        await interaction.followup.send("Not enough evidence.")
+        return
+    context = build_context(docs)
+    user_prompt = format_user_prompt(name, stage, check_size, horizon, context)
+    api_key = os.getenv("FRIENDLI_API_KEY") or os.getenv("OPENAI_API_KEY")
+    llm = OpenAI(api_key=api_key)
+    response = llm.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0.2,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        response_format={"type": "json_object"},
+    )
+    try:
+        data = json.loads(response.choices[0].message.content)
+    except Exception:
+        await interaction.followup.send("LLM response parsing error", ephemeral=True)
+        return
+
+    embed = discord.Embed(title=f"{name} Memo")
+    embed.add_field(name="Verdict", value=data.get("verdict", "-"), inline=False)
+    scores = data.get("scores", {})
+    score_lines = "\n".join(f"{k}: {v}" for k, v in scores.items())
+    embed.add_field(name="Scorecard", value=score_lines or "-", inline=False)
+    embed.add_field(name="Pros", value="\n".join(data.get("pros", [])) or "-", inline=False)
+    embed.add_field(name="Cons", value="\n".join(data.get("cons", [])) or "-", inline=False)
+    embed.add_field(name="Key Metrics", value="\n".join(data.get("key_metrics", [])) or "-", inline=False)
+    embed.add_field(name="Biggest Risks", value="\n".join(data.get("biggest_risks", [])) or "-", inline=False)
+    embed.add_field(name="Fit for Profile", value=data.get("fit_for_profile", "-"), inline=False)
+    sources = [f"[{i+1}] {doc[2]}" for i, doc in enumerate(docs)]
+    embed.add_field(name="Sources", value="\n".join(sources) or "-", inline=False)
+    embed.set_footer(text=data.get("disclaimer", ""))
+    await interaction.followup.send(embed=embed)
+
+
+def main() -> None:
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        raise ValueError("DISCORD_TOKEN not set")
+    client.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/coderabbit.txt
+++ b/data/coderabbit.txt
@@ -1,0 +1,5 @@
+CodeRabbit One-Pager | https://coderabbit.ai
+CodeRabbit offers AI-powered code review for Git repositories. It integrates with CI pipelines to provide automated code feedback.
+The product supports multiple programming languages and highlights style issues, bugs, and security concerns.
+Founders are ex-Google engineers with experience in large-scale code analysis.
+Early adopters include several open-source maintainers and small SaaS teams.

--- a/data/friendliai.txt
+++ b/data/friendliai.txt
@@ -1,0 +1,5 @@
+FriendliAI One-Pager | https://friendli.ai
+FriendliAI builds efficient inference infrastructure for LLMs. The company focuses on reducing compute costs while maintaining high performance.
+It partners with enterprise clients to deploy optimized models on their own hardware or via FriendliAI's managed service.
+The team previously developed performance libraries for TPU and GPU architectures.
+Current traction includes multiple pilot deployments with early revenue.

--- a/data/weaviate.txt
+++ b/data/weaviate.txt
@@ -1,0 +1,5 @@
+Weaviate One-Pager | https://weaviate.io
+Weaviate is an open-source vector database designed for building AI-native applications. It stores data objects and vector embeddings to enable semantic search and retrieval.
+The platform supports hybrid search, GraphQL, and modular extensions for various vectorizers.
+The company offers a managed cloud service and an active community.
+Recent releases include enhanced sharding and replication features for scalability.

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,43 @@
+"""Offline ingestion script for one-pager documents."""
+from __future__ import annotations
+
+import argparse
+from typing import Tuple
+
+from weaviate_client import (
+    build_context,
+    chunk_text,
+    embed_chunks,
+    get_client,
+    upsert_chunks,
+)
+
+
+
+def parse_document(path: str) -> Tuple[str, str, str]:
+    """Parse a one-pager file into (title, url, body)."""
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().strip().splitlines()
+    header = lines[0]
+    title, url = [p.strip() for p in header.split("|", 1)]
+    body = "\n".join(lines[1:])
+    return title, url, body
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest a startup one-pager")
+    parser.add_argument("path", help="Path to one-pager text file")
+    parser.add_argument("--name", required=True, help="Canonical company name")
+    args = parser.parse_args()
+
+    title, url, body = parse_document(args.path)
+    chunks = chunk_text(body)
+    vectors = embed_chunks(chunks)
+
+    client = get_client()
+    upsert_chunks(client, args.name, title, url, chunks, vectors)
+    print(f"Ingested {len(chunks)} chunks for {args.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,40 @@
+"""Prompt templates for the VC decision memo agent."""
+from __future__ import annotations
+
+SYSTEM_PROMPT = (
+    "You are a venture analyst. Use ONLY the provided context. "
+    "If insufficient, reply exactly: \"Not enough evidence.\" "
+    "Score each pillar 0–5 from evidence present. Return concise JSON only."
+)
+
+USER_TEMPLATE = (
+    "Startup: {name}\n"
+    "Investor constraints: stage={stage}, check_size={check_size}, horizon={horizon}\n\n"
+    "Context (numbered, cite as [1], [2]…):\n{context}\n\n"
+    "Return JSON keys:\n"
+    "- verdict: \"Consider\" | \"Watchlist\" | \"Pass\"\n"
+    "- scores: {team, problem, market, moat, traction, gtm, unit_economics, risks}\n"
+    "- pros: [2-3 bullets with [#] citations]\n"
+    "- cons: [2-3 bullets with [#] citations]\n"
+    "- key_metrics: [1-3 items]\n"
+    "- biggest_risks: [1-2 bullets]\n"
+    "- fit_for_profile: \"1-2 sentences referencing stage/check_size\"\n"
+    "- disclaimer: short non-advisory note"
+)
+
+
+def format_user_prompt(
+    name: str,
+    stage: str,
+    check_size: str,
+    horizon: str,
+    context: str,
+) -> str:
+    """Format the user prompt given parameters and retrieved context."""
+    return USER_TEMPLATE.format(
+        name=name,
+        stage=stage,
+        check_size=check_size,
+        horizon=horizon,
+        context=context,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+discord.py
+weaviate-client
+openai
+tiktoken
+langchain
+python-dotenv

--- a/weaviate_client.py
+++ b/weaviate_client.py
@@ -1,0 +1,113 @@
+"""Utilities for interacting with a Weaviate instance."""
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Tuple
+
+import tiktoken
+import weaviate
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+CLASS_NAME = "CompanyDoc"
+CHUNK_SIZE = 600  # tokens
+
+
+def get_client() -> weaviate.Client:
+    """Create a Weaviate client using environment variables."""
+    url = os.getenv("WEAVIATE_URL")
+    api_key = os.getenv("WEAVIATE_API_KEY")
+    if not url:
+        raise ValueError("WEAVIATE_URL is not set")
+    auth = weaviate.AuthApiKey(api_key) if api_key else None
+    client = weaviate.Client(url, auth_client_secret=auth)
+    return client
+
+
+def ensure_schema(client: weaviate.Client) -> None:
+    """Ensure the CompanyDoc class exists."""
+    schema = {
+        "class": CLASS_NAME,
+        "vectorizer": "none",
+        "properties": [
+            {"name": "name", "dataType": ["text"]},
+            {"name": "title", "dataType": ["text"]},
+            {"name": "url", "dataType": ["text"]},
+            {"name": "text", "dataType": ["text"]},
+        ],
+    }
+    if not client.schema.exists(CLASS_NAME):
+        client.schema.create_class(schema)
+
+
+def chunk_text(text: str, chunk_size: int = CHUNK_SIZE) -> List[str]:
+    """Split text into roughly token-sized chunks."""
+    enc = tiktoken.get_encoding("cl100k_base")
+    tokens = enc.encode(text)
+    chunks = []
+    for i in range(0, len(tokens), chunk_size):
+        chunk_tokens = tokens[i : i + chunk_size]
+        chunks.append(enc.decode(chunk_tokens))
+    return chunks
+
+
+def embed_chunks(chunks: Iterable[str]) -> List[List[float]]:
+    """Embed chunks using the OpenAI embedding endpoint."""
+    api_key = os.getenv("FRIENDLI_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("No embedding API key provided")
+    client = OpenAI(api_key=api_key)
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=list(chunks),
+    )
+    return [d.embedding for d in response.data]
+
+
+def upsert_chunks(
+    client: weaviate.Client,
+    name: str,
+    title: str,
+    url: str,
+    chunks: List[str],
+    vectors: List[List[float]],
+) -> None:
+    """Upsert embedded chunks into Weaviate."""
+    ensure_schema(client)
+    with client.batch as batch:
+        for idx, (text, vector) in enumerate(zip(chunks, vectors)):
+            obj = {
+                "name": name,
+                "title": title,
+                "url": url,
+                "text": text,
+            }
+            batch.add_data_object(obj, class_name=CLASS_NAME, vector=vector)
+
+
+def query_company(
+    client: weaviate.Client, name: str, k: int = 5
+) -> List[Tuple[str, float, str]]:
+    """Retrieve top-k chunks for a company by name and semantic similarity."""
+    near_text = {"concepts": [name]}
+    result = (
+        client.query.get(CLASS_NAME, ["text", "title", "url"])
+        .with_where({"path": ["name"], "operator": "Equal", "valueText": name})
+        .with_near_text(near_text)
+        .with_limit(k)
+        .with_additional(["distance"])
+        .do()
+    )
+    docs = result["data"]["Get"].get(CLASS_NAME, [])
+    return [(d["text"], d["_additional"]["distance"], d.get("title", "")) for d in docs]
+
+
+def build_context(docs: List[Tuple[str, float, str]]) -> str:
+    """Build context string with numbered citations."""
+    lines = []
+    for i, (text, _dist, title) in enumerate(docs, start=1):
+        snippet = text.replace("\n", " ")[:200]
+        lines.append(f"[{i}] {title} :: {snippet}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- scaffold Discord bot with `/ingest_company` and `/vc_decide` commands
- add Weaviate helpers, prompts, and ingestion script
- provide sample one-pagers, environment template, and setup docs

## Testing
- `python -m py_compile bot.py ingest.py prompts.py weaviate_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e05954588327a7e6923c4e0eb580